### PR TITLE
move, center, bold navigation links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,16 @@
 ---
 layout: default
 ---
+<!-- Post prev/next buttons -->
+<div align="center">
+{% if page.previous %}
+   <b><a rel="prev" href="{{ page.previous.url }}">&laquo; {{ page.previous.title }} &there4;</a></b>
+ {% endif %}
+   <a href="http://gaylin.github.io/blog/">Graphological Legerdemain</a>
+ {% if page.next %}
+   <b><a rel="next" href="{{ page.next.url }}">&there4; {{ page.next.title }} &raquo;</a></b>
+ {% endif %}
+</div>
 <!-- Post title and date info -->
 <h1>{{ page.title }}</h1>
 <p class="meta">{{ page.date | date_to_long_string }}</p>
@@ -8,14 +18,6 @@ layout: default
 <div class="post">
   {{ content }}
 </div>
-<!-- Post prev/next buttons -->
-{% if page.previous %}
-   <a rel="prev" href="{{ page.previous.url }}">&laquo; {{ page.previous.title }} &there4;</a>
- {% endif %}
- <a href="http://gaylin.github.io/blog/">Graphological Legerdemain</a>
- {% if page.next %}
-   <a rel="next" href="{{ page.next.url }}">&there4; {{ page.next.title }} &raquo;</a>
- {% endif %}
 <!-- Post comments -->
 <div class="postcomments">
 	{% include disqus.html %}


### PR DESCRIPTION
For real this time, move everything above the title, and bold just the two previous and next links, not the home link. Keep the same size text to avoid competing with the post heading, but center it to make it more prominent. Fixes #17.