### PR TITLE
add separator inline

### DIFF
--- a/_posts/2015-03-01-and-so-it-begins.md
+++ b/_posts/2015-03-01-and-so-it-begins.md
@@ -2,10 +2,9 @@
 layout: post
 title: "And so it begins"
 date: 2015-03-01
-excerpt: Wherein I begin this journey of learning github and jekyll and an HTML version that doesn't start with 1.x...
 ---
 
-I'm not old. I certainly don't feel it. But the simple fact is that the majority of my cow-orkers[1] were born after MrMr[2] and I tied the knot. I try not to point it out but I'm at that age where I can't help but think "Oh for fuck's sake. What do you mean you don't know who \<insert 80s band name\> is?". I've been in this career path for longer.
+I'm not old. I certainly don't feel it. But the simple fact is that the majority of my cow-orkers[1] were born after MrMr[2] and I tied the knot. I try not to point it out but I'm at that age where I can't help but think "Oh for fuck's sake. What do you mean you don't know who \<insert 80s band name\> is?". <!--more--> I've been in this career path for longer.
 
 So, per my "Hello World" commit on the home page (at least until I rip that puppy off there for something more festive and beeyooteous), I'm doing this because:
 

--- a/_posts/2015-03-08-channeling-princess-leia.md
+++ b/_posts/2015-03-08-channeling-princess-leia.md
@@ -4,7 +4,7 @@ title: "Channeling Princess Leia"
 date: 2015-03-08
 ---
 
-MrMr wonders sometimes, I'm sure, why I get up before dawn. For a long time it was simply that I hated driving in rush-hour traffic so much that going in to work early was the only way to keep my sanity. At this point, now that I work exclusively out of my home office, I really have no other excuse than habit.[1] Even on the weekends, which probably bakes his noodle more than any other time.[2]
+MrMr wonders sometimes, I'm sure, why I get up before dawn. For a long time it was simply that I hated driving in rush-hour traffic so much that going in to work early was the only way to keep my sanity. <!--more-->At this point, now that I work exclusively out of my home office, I really have no other excuse than habit.[1] Even on the weekends, which probably bakes his noodle more than any other time.[2]
 
 So here I sit on a Sunday morning, awake at the blindingly late hour of 9am[3] and I have to make a confession: I suck at this code manipulation thing worse than I thought. But I've figured out why.
 

--- a/_posts/2015-03-14-there-and-back-again.md
+++ b/_posts/2015-03-14-there-and-back-again.md
@@ -4,7 +4,7 @@ title: "Because Mr. Eco was right"
 date: 2015-03-14
 ---
 
-This week seems to be my week for coding mistakes (in as much as I can call it coding, that is[1]). I am still relying a great deal too much on the viewing format of something and not enough on what the code is telling me about how something will look.<!--more-->
+This week seems to be my week for coding mistakes (in as much as I can call it coding, that is[1]). <!--more-->I am still relying a great deal too much on the viewing format of something and not enough on what the code is telling me about how something will look.
 
 I sat down this week and work and renamed in excess of 200 image files to a more consistent format. Sadly it wasn't a case where I could beg one of my awesome cow-orkers to wave a magic scripting wand. The files really did require human eyes to look at the content of the image and say "Well obviously 'screenshot01.png' isn't going to cut it here." We were aiming for a loose BEM-style naming scheme[2].
 


### PR DESCRIPTION
I originally tested the blog post excerpt separator at the end of a paragraph instead of in the middle of one like I should have. This corrects that.